### PR TITLE
VS 2017.5.6 example project compilation fix

### DIFF
--- a/include/bitsery/adapter_reader.h
+++ b/include/bitsery/adapter_reader.h
@@ -240,7 +240,7 @@ namespace bitsery {
             auto bitsLeft = size;
             T res{};
             while (bitsLeft > 0) {
-                auto bits = std::min(bitsLeft, details::BitsSize<UnsignedValue>::value);
+                auto bits = (std::min)(bitsLeft, details::BitsSize<UnsignedValue>::value);
                 if (m_scratchBits < bits) {
                     UnsignedValue tmp;
                     _reader.template readBytes<sizeof(UnsignedValue), UnsignedValue>(tmp);

--- a/include/bitsery/adapter_writer.h
+++ b/include/bitsery/adapter_writer.h
@@ -295,7 +295,7 @@ namespace bitsery {
             auto value = v;
             auto bitsLeft = size;
             while (bitsLeft > 0) {
-                auto bits = std::min(bitsLeft, valueSize);
+                auto bits = (std::min)(bitsLeft, valueSize);
                 _scratch |= static_cast<ScratchType>( value ) << _scratchBits;
                 _scratchBits += bits;
                 if (_scratchBits >= valueSize) {
@@ -324,7 +324,7 @@ namespace bitsery {
             }
         }
 
-        const UnsignedType _MASK = std::numeric_limits<UnsignedType>::max();
+        const UnsignedType _MASK = (std::numeric_limits<UnsignedType>::max)();
         ScratchType _scratch{};
         size_t _scratchBits{};
         TWriter& _writer;

--- a/include/bitsery/traits/core/std_defaults.h
+++ b/include/bitsery/traits/core/std_defaults.h
@@ -73,7 +73,7 @@ namespace bitsery {
                 auto newSize = static_cast<size_t>(container.size() * 1.5 + 128);
                 //make data cache friendly
                 newSize -= newSize % 64;//64 is cache line size
-                container.resize(std::max(newSize, container.capacity()));
+                container.resize((std::max)(newSize, container.capacity()));
             }
             using TIterator = typename T::iterator;
             using TValue = typename ContainerTraits<T>::TValue;


### PR DESCRIPTION
Tests were completed in travis.ci: 
[![Build Status](https://travis-ci.com/AJIOB/bitsery.svg?branch=master)](https://travis-ci.com/AJIOB/bitsery)
This patch fixes compilation on latest Windows compilators from Microsoft (MSVC), because windows headers define `max` and `min` as macros by default.