### PR TITLE
Added serializer/deserializer "cereal like" interface 

### DIFF
--- a/include/bitsery/deserializer.h
+++ b/include/bitsery/deserializer.h
@@ -102,6 +102,15 @@ namespace bitsery {
             archive(std::forward<TArgs>(tail)...);
         }
 
+        template <typename T, typename... TArgs>
+        BasicDeserializer &operator()(T &&head, TArgs &&... tail) {
+            //serialize object
+            details::ArchiveFunction<BasicDeserializer, T>::invoke(*this, std::forward<T>(head));
+            //expand other elements
+            archive(std::forward<TArgs>(tail)...);
+            return *this;
+        }
+
         /*
          * value
          */

--- a/include/bitsery/serializer.h
+++ b/include/bitsery/serializer.h
@@ -100,6 +100,13 @@ namespace bitsery {
             archive(std::forward<TArgs>(tail)...);
         }
 
+        template <typename T, typename... TArgs>
+        BasicSerializer &operator()(T &&head, TArgs &&... tail) {
+            details::ArchiveFunction<BasicSerializer, T>::invoke(*this, std::forward<T>(head));
+            archive(std::forward<TArgs>(tail)...);
+            return *this;
+        }
+
         /*
          * value overloads
          */


### PR DESCRIPTION
Added interface BasicSerializer &operator()(T &&head, TArgs &&... tail) and BasicDeserializer &operator()(T &&head, TArgs &&... tail), which are cereal like intefaces so such format of serialization functions were possible:

template<class Archive>
void serialize(Archive & ar, DataType& d){
    ar(d.data1, d.data2....);
}