### PR TITLE
Allow certain cases in serialization using flexible

### DIFF
--- a/include/bitsery/deserializer.h
+++ b/include/bitsery/deserializer.h
@@ -97,7 +97,8 @@ namespace bitsery {
         template<typename T, typename ... TArgs>
         void archive(T &&head, TArgs &&... tail) {
             //serialize object
-            details::ArchiveFunction<BasicDeserializer, T>::invoke(*this, std::forward<T>(head));
+            details::ArchiveFunction<BasicDeserializer, T>::invoke(*this, std::forward<T>(head),
+                std::false_type());
             //expand other elements
             archive(std::forward<TArgs>(tail)...);
         }
@@ -105,7 +106,8 @@ namespace bitsery {
         template <typename T, typename... TArgs>
         BasicDeserializer &operator()(T &&head, TArgs &&... tail) {
             //serialize object
-            details::ArchiveFunction<BasicDeserializer, T>::invoke(*this, std::forward<T>(head));
+            details::ArchiveFunction<BasicDeserializer, T>::invoke(*this, std::forward<T>(head),
+                std::false_type());
             //expand other elements
             archive(std::forward<TArgs>(tail)...);
             return *this;

--- a/include/bitsery/details/serialization_common.h
+++ b/include/bitsery/details/serialization_common.h
@@ -53,6 +53,10 @@ namespace bitsery {
 
     };
 
+    namespace flexible{
+        struct ArchiveWrapperFnc;
+    }
+
     //when call to serialize function is ambiguous (member and non-member serialize function exists for a type)
     //specialize this class by inheriting from either UseNonMemberFnc or UseMemberFnc
     //e.g.
@@ -273,10 +277,17 @@ namespace bitsery {
         template<typename S, typename T, typename Enabled = void>
         struct ArchiveFunction {
 
-            static void invoke(S &s, T &&obj) {
+            static void invoke(S &s, T &&obj, std::true_type) {
                 static_assert(IsFlexibleIncluded<S, T>::value,
                               "\nPlease include '<bitsery/flexible.h>' to use 'archive' function:\n");
 
+                archiveProcess(s, std::forward<T>(obj));
+            }
+            static void invoke(S &s, T &&obj, std::false_type) {
+                static_assert(IsFlexibleIncluded<S, T>::value,
+                              "\nPlease include '<bitsery/flexible.h>' to use 'archive' function:\n");
+                static_assert(std::is_reference<T>::value||std::is_base_of<flexible::ArchiveWrapperFnc, T>::value,
+                              "\nOnly archive behaviour modifying functions can be passed by rvalue to deserializer\n");
                 archiveProcess(s, std::forward<T>(obj));
             }
         };

--- a/include/bitsery/flexible.h
+++ b/include/bitsery/flexible.h
@@ -40,8 +40,6 @@ namespace bitsery {
         //overload when T is rvalue type, only allowable for behaviour modifying functions for deserializer
         template<typename S, typename T>
         void archiveProcessImpl(S &s, T &&head, std::false_type) {
-            static_assert(std::is_base_of<ArchiveWrapperFnc, T>::value,
-                          "\nOnly archive behaviour modifying functions can be passed by rvalue to deserializer\n");
             serialize(s, head);
         }
 

--- a/include/bitsery/serializer.h
+++ b/include/bitsery/serializer.h
@@ -95,14 +95,16 @@ namespace bitsery {
         template<typename T, typename ... TArgs>
         void archive(T &&head, TArgs &&... tail) {
             //serialize object
-            details::ArchiveFunction<BasicSerializer, T>::invoke(*this, std::forward<T>(head));
+            details::ArchiveFunction<BasicSerializer, T>::invoke(*this, std::forward<T>(head),
+                std::true_type());
             //expand other elements
             archive(std::forward<TArgs>(tail)...);
         }
 
         template <typename T, typename... TArgs>
         BasicSerializer &operator()(T &&head, TArgs &&... tail) {
-            details::ArchiveFunction<BasicSerializer, T>::invoke(*this, std::forward<T>(head));
+            details::ArchiveFunction<BasicSerializer, T>::invoke(*this, std::forward<T>(head),
+                std::true_type());
             archive(std::forward<TArgs>(tail)...);
             return *this;
         }


### PR DESCRIPTION
In certain cases the serialization and deserialization functions needs to be defined separately. Currently if the user defined “serialize” and “deserialize” functions, and wants to use “flexible” format (such as using ar.archive(data)) and in serialization function, if the input format is, e.x. function returned values (which shall be valid since no modification happens to the input), the “serialize” function will failed by static_assert error. The MR keeps the previous static_assertion requirement for “deserialize” function and allowed the above case to run.