### PR TITLE
Fixed unknown-pragmas warnings on non-MSVC.

### DIFF
--- a/include/bitsery/details/adapter_common.h
+++ b/include/bitsery/details/adapter_common.h
@@ -146,12 +146,16 @@ namespace bitsery {
          */
         // add test data in separate struct, because some compilers only support constexpr functions with return-only body
         // suppress msvc warnings.
+#ifdef _MSC_VER
         #pragma warning( disable : 4310 )
+#endif
         struct EndiannessTestData {
             static constexpr uint32_t _sample4Bytes = 0x01020304;
             static constexpr uint8_t _sample1stByte = (const uint8_t &) _sample4Bytes;
         };
+#ifdef _MSC_VER
         #pragma warning( default : 4310 )
+#endif
 
         constexpr EndiannessType getSystemEndianness() {
             static_assert(EndiannessTestData::_sample1stByte == 0x04 || EndiannessTestData::_sample1stByte == 0x01,


### PR DESCRIPTION
Changes:
Surrounded the MSVC-specific "disable warning" pragmas with MSVC guards.

Tested on:
g++.exe (Rev2, Built by MSYS2 project) 9.3.0
g++ (Ubuntu 9.3.0-10ubuntu2) 9.3.0
Haven't checked on MSVC.