### PR TITLE
Avoid reinitializing nontrival std::optional

### DIFF
--- a/include/bitsery/ext/std_optional.h
+++ b/include/bitsery/ext/std_optional.h
@@ -56,6 +56,17 @@ namespace bitsery {
                 if (_alignBeforeData)
                     des.adapter().align();
                 if (exists) {
+                    // Reinitializing nontrivial types may be expensive
+                    // especially when they reference heap data, so if `obj`
+                    // already holds a value then we'll deserialize into the
+                    // existing object
+                    if constexpr (!std::is_trivial_v<T>) {
+                        if (obj) {
+                            fnc(des, *obj);
+                            return;
+                        }
+                    }
+
                     obj = ::bitsery::Access::create<T>();
                     fnc(des, *obj);
                 } else {


### PR DESCRIPTION
This is related to #76 and #77. During a round of optimizations I decided to check whether `bitsery::ext::StdOptional` also always reinitializes the `std::optional<T>` during deserialization, and it turns out it does. It sounds like it would make sense to apply the same optimization there, thus avoiding reinitializing the object when deserializing a value into an `std::optional<T>` that already holds a `T` if `T` is a nontrivial type.