### PR TITLE
Add Missing header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build/
 cmake-build-*
 CTestConfig.cmake
 Testing/
+*.gch

--- a/include/bitsery/adapter/measure_size.h
+++ b/include/bitsery/adapter/measure_size.h
@@ -23,6 +23,10 @@
 #ifndef BITSERY_ADAPTER_MEASURE_SIZE_H
 #define BITSERY_ADAPTER_MEASURE_SIZE_H
 
+#include <cstddef>
+#include <type_traits>
+#include "../details/adapter_common.h"
+
 namespace bitsery {
 
 

--- a/include/bitsery/adapter/stream.h
+++ b/include/bitsery/adapter/stream.h
@@ -26,6 +26,7 @@
 #include "../details/adapter_common.h"
 #include "../traits/array.h"
 #include <ios>
+#include <limits>
 
 namespace bitsery {
 

--- a/include/bitsery/brief_syntax/map.h
+++ b/include/bitsery/brief_syntax/map.h
@@ -25,6 +25,7 @@
 #define BITSERY_BRIEF_SYNTAX_TYPE_STD_MAP_H
 
 #include <map>
+#include <limits>
 #include "../ext/std_map.h"
 
 namespace bitsery {

--- a/include/bitsery/brief_syntax/queue.h
+++ b/include/bitsery/brief_syntax/queue.h
@@ -25,6 +25,7 @@
 #define BITSERY_BRIEF_SYNTAX_TYPE_STD_QUEUE_H
 
 #include "../ext/std_queue.h"
+#include <limits>
 
 namespace bitsery {
     template<typename S, typename T, typename C>

--- a/include/bitsery/brief_syntax/set.h
+++ b/include/bitsery/brief_syntax/set.h
@@ -25,6 +25,7 @@
 #define BITSERY_BRIEF_SYNTAX_TYPE_STD_SET_H
 
 #include <set>
+#include <limits>
 #include "../ext/std_set.h"
 
 namespace bitsery {

--- a/include/bitsery/brief_syntax/stack.h
+++ b/include/bitsery/brief_syntax/stack.h
@@ -24,6 +24,7 @@
 #ifndef BITSERY_BRIEF_SYNTAX_TYPE_STD_STACK_H
 #define BITSERY_BRIEF_SYNTAX_TYPE_STD_STACK_H
 
+#include <limits>
 #include "../ext/std_stack.h"
 
 namespace bitsery {

--- a/include/bitsery/brief_syntax/unordered_map.h
+++ b/include/bitsery/brief_syntax/unordered_map.h
@@ -25,6 +25,7 @@
 #define BITSERY_BRIEF_SYNTAX_TYPE_STD_UNORDERED_MAP_H
 
 #include <unordered_map>
+#include <limits>
 #include "../ext/std_map.h"
 
 namespace bitsery {

--- a/include/bitsery/brief_syntax/unordered_set.h
+++ b/include/bitsery/brief_syntax/unordered_set.h
@@ -24,6 +24,7 @@
 #ifndef BITSERY_BRIEF_SYNTAX_TYPE_STD_UNORDERED_SET_H
 #define BITSERY_BRIEF_SYNTAX_TYPE_STD_UNORDERED_SET_H
 
+#include <limits>
 #include <unordered_set>
 #include "../ext/std_set.h"
 

--- a/include/bitsery/details/brief_syntax_common.h
+++ b/include/bitsery/details/brief_syntax_common.h
@@ -24,6 +24,7 @@
 #define BITSERY_DETAILS_BRIEF_SYNTAX_COMMON_H
 
 #include "../traits/core/traits.h"
+#include "serialization_common.h"
 #include <limits>
 
 namespace bitsery {

--- a/include/bitsery/serializer.h
+++ b/include/bitsery/serializer.h
@@ -27,6 +27,7 @@
 #include "details/serialization_common.h"
 #include "details/adapter_common.h"
 #include <cassert>
+#include <limits>
 
 namespace bitsery {
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -66,6 +66,7 @@ endif()
 
 # Check missing includes for each header file in include/bitsery
 # We compile each header files individually to check if each header contains all required includes
+# Code adopted from `https://stackoverflow.com/questions/57885042`
 # Usage:
 # run from repo root directory
 # > mkdir -p build && cd build
@@ -74,13 +75,12 @@ endif()
 add_custom_target(check_includes)
 get_directory_property(ParentDir PARENT_DIRECTORY)
 if (ParentDir)
+    message("add header include test, run test with 'make check_includes'")
     file(GLOB_RECURSE HeaderFiles "${ParentDir}/include/bitsery/*.h")
     FOREACH (HeaderFile ${HeaderFiles})
-        # message(STATUS "${HeaderFile}")
         SET(CHK_TARGET_NAME "${HeaderFile}.chk")
+        STRING(REPLACE "${ParentDir}/include/bitsery/" "" CHK_TARGET_NAME ${CHK_TARGET_NAME})
         STRING(REGEX REPLACE "/" "_" CHK_TARGET_NAME ${CHK_TARGET_NAME})
-        STRING(REGEX REPLACE "\\." "_" CHK_TARGET_NAME ${CHK_TARGET_NAME})
-        STRING(REGEX REPLACE ":" "_" CHK_TARGET_NAME ${CHK_TARGET_NAME})
         STRING(REGEX REPLACE "\\\\" "_" CHK_TARGET_NAME ${CHK_TARGET_NAME})
         add_custom_target(
             ${CHK_TARGET_NAME}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -63,3 +63,30 @@ if (ParentDir)
     target_sources(bitsery.dummy_for_ide PRIVATE ${HeadersForIDE} serialization_test_utils.h)
     target_link_libraries(bitsery.dummy_for_ide PRIVATE GTest::Main Bitsery::bitsery)
 endif()
+
+# Check missing includes for each header file in include/bitsery
+# We compile each header files individually to check if each header contains all required includes
+# Usage:
+# run from repo root directory
+# > mkdir -p build && cd build
+# > cmake -D BITSERY_BUILD_TESTS=1 ..
+# > make check_includes
+add_custom_target(check_includes)
+get_directory_property(ParentDir PARENT_DIRECTORY)
+if (ParentDir)
+    file(GLOB_RECURSE HeaderFiles "${ParentDir}/include/bitsery/*.h")
+    FOREACH (HeaderFile ${HeaderFiles})
+        # message(STATUS "${HeaderFile}")
+        SET(CHK_TARGET_NAME "${HeaderFile}.chk")
+        STRING(REGEX REPLACE "/" "_" CHK_TARGET_NAME ${CHK_TARGET_NAME})
+        STRING(REGEX REPLACE "\\." "_" CHK_TARGET_NAME ${CHK_TARGET_NAME})
+        STRING(REGEX REPLACE ":" "_" CHK_TARGET_NAME ${CHK_TARGET_NAME})
+        STRING(REGEX REPLACE "\\\\" "_" CHK_TARGET_NAME ${CHK_TARGET_NAME})
+        add_custom_target(
+            ${CHK_TARGET_NAME}
+            COMMAND ${CMAKE_CXX_COMPILER} -c ${HeaderFile}
+            VERBATIM
+        )
+        add_dependencies(check_includes ${CHK_TARGET_NAME})
+    ENDFOREACH ()
+endif()


### PR DESCRIPTION
Hi,

I can not compile with gcc 11.1.0 because of the missing `#include <limits>` for [this](https://github.com/fraillt/bitsery/blob/4ff80c642626d33e1845c0ffcb032c076cb04a39/include/bitsery/serializer.h#L155) line. After adding the include, the compilation works fine.

Is there a reason why `#include <limits>` is not included in `serializer.h`?