### PR TITLE
pass cursor and needed byte space to BufferAdapterTraits::increaseBufferSize

### DIFF
--- a/include/bitsery/adapter/buffer.h
+++ b/include/bitsery/adapter/buffer.h
@@ -256,7 +256,7 @@ namespace bitsery {
         void init(std::true_type) {
             //resize buffer immediately, because we need output iterator at valid position
             if (traits::ContainerTraits<Buffer>::size(*_buffer) == 0u) {
-                traits::BufferAdapterTraits<Buffer>::increaseBufferSize(*_buffer);
+                traits::BufferAdapterTraits<Buffer>::increaseBufferSize(*_buffer, 0, 0);
             }
             updateIteratorAndSize();
         }
@@ -268,7 +268,7 @@ namespace bitsery {
                 std::copy_n(data, SIZE, _beginIt + static_cast<diff_t>(_currOffset));
                 _currOffset = newOffset;
             } else {
-                traits::BufferAdapterTraits<Buffer>::increaseBufferSize(*_buffer);
+                traits::BufferAdapterTraits<Buffer>::increaseBufferSize(*_buffer, _currOffset, SIZE);
                 updateIteratorAndSize();
                 writeInternalValueImpl<SIZE>(data, std::true_type{});
             }
@@ -280,7 +280,7 @@ namespace bitsery {
                 std::copy_n(data, size, _beginIt + static_cast<diff_t>(_currOffset));
                 _currOffset = newOffset;
             } else {
-                traits::BufferAdapterTraits<Buffer>::increaseBufferSize(*_buffer);
+                traits::BufferAdapterTraits<Buffer>::increaseBufferSize(*_buffer, _currOffset, size);
                 updateIteratorAndSize();
                 writeInternalBufferImpl(data, size, std::true_type{});
             }
@@ -290,7 +290,7 @@ namespace bitsery {
             if (pos <= _bufferSize) {
                 _currOffset = pos;
             } else {
-                traits::BufferAdapterTraits<Buffer>::increaseBufferSize(*_buffer);
+                traits::BufferAdapterTraits<Buffer>::increaseBufferSize(*_buffer, _currOffset, sizeof(size_t));
                 updateIteratorAndSize();
                 setCurrentWritePos(pos, std::true_type{});
             }

--- a/include/bitsery/traits/core/std_defaults.h
+++ b/include/bitsery/traits/core/std_defaults.h
@@ -84,7 +84,7 @@ namespace bitsery {
         template <typename T>
         struct StdContainerForBufferAdapter<T, true> {
 
-            static void increaseBufferSize(T& container) {
+            static void increaseBufferSize(T& container, size_t cursor, size_t atLeastN) {
                 //since we're writing to buffer use different resize strategy than default implementation
                 //when small size grow faster, to avoid thouse 2/4/8/16... byte allocations
                 auto newSize = static_cast<size_t>(static_cast<double>(container.size()) * 1.5) + 128;

--- a/include/bitsery/traits/core/traits.h
+++ b/include/bitsery/traits/core/traits.h
@@ -148,7 +148,9 @@ namespace bitsery {
             //it is used to dramaticaly improve performance by updating buffer directly
             //instead of using back_insert_iterator to append each byte to buffer.
 
-            static void increaseBufferSize(T& ) {
+            // paramter 2 == the current cursor position in the buffer
+            // parameter 3 == we need at least these number of bytes, but 0 when seeding the buffer, up to implementation to decide
+            static void increaseBufferSize(T&, size_t, size_t) {
                 static_assert(std::is_void<T>::value,
                               "Define BufferAdapterTraits or include from <bitsery/traits/...> to use as buffer adapter container");
             }


### PR DESCRIPTION
two insights seen when resizing buffers...

1) when inserting an object much larger than the current buffer size, the current implementation will loop many times until the buffer grows large enough, burning several unnecessary allocations and memcpy-s in the worst case. so inform the implementation how many bytes we need.

2) when implementing an alloc + memcpy, since the buffer's length isn't updated until after the serialization, we're forced to copy the entire capacity. though this capacity is insufficient to accommodate the new addition, we still might be copying excess bytes. very mildly cleaner this way. wouldn't warrant a PR without 1) though.