### PR TITLE
Changes the code path for arrays of bytes in big endian to not loop on the array.

### DIFF
--- a/include/bitsery/details/adapter_common.h
+++ b/include/bitsery/details/adapter_common.h
@@ -194,10 +194,11 @@ getSystemEndianness()
            : EndiannessType::BigEndian;
 }
 
-template<typename Config>
+template<typename Config, typename T>
 using ShouldSwap =
   std::integral_constant<bool,
-                         Config::Endianness != details::getSystemEndianness()>;
+                         Config::Endianness != details::getSystemEndianness() &&
+                           sizeof(T) != 1>;
 
 /**
  * helper types to work with bits
@@ -287,7 +288,7 @@ struct OutputAdapterBaseCRTP
   {
     static_assert(std::is_integral<T>(), "");
     static_assert(sizeof(T) == SIZE, "");
-    writeSwappedValue(&v, ShouldSwap<typename Adapter::TConfig>{});
+    writeSwappedValue(&v, ShouldSwap<typename Adapter::TConfig, T>{});
   }
 
   template<size_t SIZE, typename T>
@@ -295,7 +296,7 @@ struct OutputAdapterBaseCRTP
   {
     static_assert(std::is_integral<T>(), "");
     static_assert(sizeof(T) == SIZE, "");
-    writeSwappedBuffer(buf, count, ShouldSwap<typename Adapter::TConfig>{});
+    writeSwappedBuffer(buf, count, ShouldSwap<typename Adapter::TConfig, T>{});
   }
 
   template<typename T>
@@ -360,7 +361,7 @@ struct InputAdapterBaseCRTP
     static_assert(sizeof(T) == SIZE, "");
     static_cast<Adapter*>(this)->template readInternalValue<sizeof(T)>(
       reinterpret_cast<typename Adapter::TValue*>(&v));
-    swapDataBits(v, ShouldSwap<typename Adapter::TConfig>{});
+    swapDataBits(v, ShouldSwap<typename Adapter::TConfig, T>{});
   }
 
   template<size_t SIZE, typename T>
@@ -370,7 +371,7 @@ struct InputAdapterBaseCRTP
     static_assert(sizeof(T) == SIZE, "");
     static_cast<Adapter*>(this)->readInternalBuffer(
       reinterpret_cast<typename Adapter::TValue*>(buf), sizeof(T) * count);
-    swapDataBits(buf, count, ShouldSwap<typename Adapter::TConfig>{});
+    swapDataBits(buf, count, ShouldSwap<typename Adapter::TConfig, T>{});
   }
 
   template<typename T>


### PR DESCRIPTION
We've been using bitsery at my job for a while, but recently we converted to big endian for our network protocol and I noticed a massive performance degradation. In debug, the impact is much, much more present to the point of making it unusable for our use case.

Changing it so that we skip the for loop on arrays of bytes fixed the issue.

I would expect the compiler to be able to optimize in release, but even there I saw a performance improvement of 2x after making this change.

Note that I only tested on MSVC because I don't have another compiler setuped.

I did not implement additional tests since this should have no functional impact, but I did run the tests.