### PR TITLE
FIX: Build error on GCC 13.x due to ommision of cstdint include

### DIFF
--- a/include/bitsery/details/adapter_common.h
+++ b/include/bitsery/details/adapter_common.h
@@ -28,6 +28,7 @@
 #include <algorithm>
 #include <cassert>
 #include <climits>
+#include <cstdint>
 
 namespace bitsery {
 


### PR DESCRIPTION
Refer to https://gcc.gnu.org/gcc-13/porting_to.html for details on why change was needed

- Added <cstdint> include to include/bitsery/details/adapter_common.h