### PR TITLE
get writeable buffer

### DIFF
--- a/include/bitsery/adapter/buffer.h
+++ b/include/bitsery/adapter/buffer.h
@@ -261,6 +261,15 @@ private:
     writeInternalImpl(data, size);
   }
 
+  TValue* writeInternalBuffer(size_t size)
+  {
+    const size_t newOffset = _currOffset + size;
+    maybeResize(newOffset, TResizable{});
+    _currOffset = newOffset;
+    return _beginIt + static_cast<diff_t>(_currOffset);
+  }
+
+
   Buffer* _buffer;
   TIterator _beginIt;
   size_t _currOffset{ 0 };

--- a/include/bitsery/details/adapter_common.h
+++ b/include/bitsery/details/adapter_common.h
@@ -300,6 +300,15 @@ struct OutputAdapterBaseCRTP
     writeSwappedBuffer(buf, count, ShouldSwap<typename Adapter::TConfig, T>{});
   }
 
+  template<size_t SIZE, typename T>
+  T* writeBuffer(size_t count)
+  {
+    static_assert(std::is_integral<T>(), "");
+    static_assert(sizeof(T) == SIZE, "");
+
+    return static_cast<Adapter*>(this)->writeInternalBuffer(count * sizeof(T));
+  }
+
   template<typename T>
   void writeBits(const T&, size_t)
   {
@@ -367,6 +376,16 @@ struct InputAdapterBaseCRTP
 
   template<size_t SIZE, typename T>
   void readBuffer(T* buf, size_t count)
+  {
+    static_assert(std::is_integral<T>(), "");
+    static_assert(sizeof(T) == SIZE, "");
+    static_cast<Adapter*>(this)->readInternalBuffer(
+      reinterpret_cast<typename Adapter::TValue*>(buf), sizeof(T) * count);
+    swapDataBits(buf, count, ShouldSwap<typename Adapter::TConfig, T>{});
+  }
+
+  template<size_t SIZE, typename T>
+  T* readBuffer(T* buf, size_t count)
   {
     static_assert(std::is_integral<T>(), "");
     static_assert(sizeof(T) == SIZE, "");

--- a/include/bitsery/details/adapter_common.h
+++ b/include/bitsery/details/adapter_common.h
@@ -384,16 +384,6 @@ struct InputAdapterBaseCRTP
     swapDataBits(buf, count, ShouldSwap<typename Adapter::TConfig, T>{});
   }
 
-  template<size_t SIZE, typename T>
-  T* readBuffer(T* buf, size_t count)
-  {
-    static_assert(std::is_integral<T>(), "");
-    static_assert(sizeof(T) == SIZE, "");
-    static_cast<Adapter*>(this)->readInternalBuffer(
-      reinterpret_cast<typename Adapter::TValue*>(buf), sizeof(T) * count);
-    swapDataBits(buf, count, ShouldSwap<typename Adapter::TConfig, T>{});
-  }
-
   template<typename T>
   void readBits(T&, size_t)
   {


### PR DESCRIPTION
i'm writing a custom extension that might invoke a 3rd party serialization method that takes a buffer to serialize into, and need to avoid an unnecessary copy (aka by first serializing into a temporary buffer then copying into the bitsery generate buffer) as these object might be many, many bytes... so i added 2 methods to extract the buffer pointer to write into.