### PR TITLE
Fix spelling error of "likely"

### DIFF
--- a/include/bitsery/bitsery.h
+++ b/include/bitsery/bitsery.h
@@ -66,7 +66,7 @@
 #endif
 
 #if __has_cpp_attribute(likely)
-#define BITSERY_LIKELY BITSERY_ATTRIBUTE(likey)
+#define BITSERY_LIKELY BITSERY_ATTRIBUTE(likely)
 #else
 #define BITSERY_LIKELY
 #endif


### PR DESCRIPTION
There is actually no real effect, but this is a misspelled C++ keyword